### PR TITLE
move testing log to "./target" of every application

### DIFF
--- a/ibroker/alarm/src/test/resources/application.properties
+++ b/ibroker/alarm/src/test/resources/application.properties
@@ -8,7 +8,7 @@ logging.level.com.openiot.cloud=INFO
 logging.level.com.openiot.cloud.alarm=DEBUG
 logging.file.max-history=10
 logging.file.max-size=50MB
-logging.file=/var/opt/log/openiot/cloudlogs/alarm.log
+logging.file=./target/alarm.log
 # for ActiveMq
 mq.host=openiot4test-infrastructure.bj.intel.com
 # for InfluxDB

--- a/ibroker/ams-api-gateway/src/test/resources/application.properties
+++ b/ibroker/ams-api-gateway/src/test/resources/application.properties
@@ -60,4 +60,4 @@ logging.level.org.springframework.security=DEBUG
 logging.level.com.intel.iot.ams=DEBUG
 logging.file.max-history=10
 logging.file.max-size=50MB
-logging.file=/var/opt/log/openiot/cloudlogs//ams-api-gateway.log
+logging.file=./target/ams-api-gateway.log

--- a/ibroker/base/src/test/resources/application.properties
+++ b/ibroker/base/src/test/resources/application.properties
@@ -30,4 +30,4 @@ logging.level.org.springframework.data=DEBUG
 logging.level.org.influxdb=DEBUG
 logging.level.com.openiot.cloud=INFO
 logging.level.com.openiot.cloud.base=DEBUG
-logging.file=/var/opt/log/openiot/cloudlogs/base.log
+logging.file=./target/base.log

--- a/ibroker/config/src/test/resources/application.properties
+++ b/ibroker/config/src/test/resources/application.properties
@@ -39,5 +39,5 @@ logging.level.com.openiot.cloud=INFO
 logging.level.com.openiot.cloud.cfg=DEBUG
 logging.file.max-history=10
 logging.file.max-size=20MB
-logging.file=./config.log
+logging.file=./target/config.log
 

--- a/ibroker/event/src/test/resources/application.properties
+++ b/ibroker/event/src/test/resources/application.properties
@@ -39,5 +39,4 @@ logging.level.com.openiot.cloud=INFO
 logging.level.com.openiot.cloud.event=DEBUG
 logging.file.max-history=10
 logging.file.max-size=50MB
-logging.file=/var/opt/log/openiot/cloudlogs/event.log
-
+logging.file=./target/event.log

--- a/ibroker/httpproxy/src/test/resources/application.properties
+++ b/ibroker/httpproxy/src/test/resources/application.properties
@@ -43,7 +43,7 @@ logging.level.com.openiot.cloud.base=DEBUG
 logging.level.com.openiot.cloud.httpproxy=DEBUG
 logging.file.max-history=10
 logging.file.max-size=50MB
-logging.file=/var/opt/log/openiot/cloudlogs/httpproxy.log
+logging.file=./target/httpproxy.log
 
 
 # for cache by redis

--- a/ibroker/ibroker/src/test/resources/application.properties
+++ b/ibroker/ibroker/src/test/resources/application.properties
@@ -30,5 +30,4 @@ logging.level.com.openiot.cloud=INFO
 logging.level.com.openiot.cloud.ibroker=DEBUG
 logging.file.max-history=10
 logging.file.max-size=50MB
-logging.file=/var/opt/log/openiot/cloudlogs/ibroker.log
-
+logging.file=./target/ibroker.log

--- a/ibroker/projectcenter/src/test/resources/application.properties
+++ b/ibroker/projectcenter/src/test/resources/application.properties
@@ -14,8 +14,8 @@ server.error.whitelabel.enabled=false
 server.tomcat.accesslog.enabled=true
 server.tomcat.accesslog.append=true
 server.tomcat.accesslog.pattern="%h %l %u %t \"%r\" %>s %b"
-server.tomcat.basedir=/var/opt/log/openiot
-server.tomcat.accesslog.directory=cloudlogs
+server.tomcat.basedir=./target
+server.tomcat.accesslog.directory=.
 server.tomcat.accesslog.prefix=projectcenter_access_log
 
 #jwt api security
@@ -37,7 +37,7 @@ logging.level.com.openiot.cloud.base=INFO
 logging.level.com.openiot.projectcenter=DEBUG
 logging.file.max-history=10
 logging.file.max-size=50MB
-logging.file=/var/opt/log/openiot/cloudlogs/projectcenter.log
+logging.file=./target/projectcenter.log
 
 # for provision
 # TBD: need to be encrypted

--- a/ibroker/sdk/src/test/resources/application.properties
+++ b/ibroker/sdk/src/test/resources/application.properties
@@ -27,4 +27,4 @@ logging.level.com.openiot.cloud=INFO
 logging.level.com.openiot.cloud.sdk=DEBUG
 logging.file.max-history=10
 logging.file.max-size=50MB
-logging.file=/var/opt/log/openiot/cloudlogs/sdk.log
+logging.file=./target/sdk.log


### PR DESCRIPTION
will not create a log directory and assign permission during building phase